### PR TITLE
Allow SecurityContext to be added to LdapConnection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Dartdap Change Log
 
+* 0.2.2 2017-09-15
+
+- Allow SecurityContext to be passed to LdapConnection and setProtocol to enable
+client certificates or custom CA roots to be added.
+
 * 0.2.1 2016-09-26
 
 - Fixed bug when port number is null.

--- a/lib/src/dartdap/client/connection_manager.dart
+++ b/lib/src/dartdap/client/connection_manager.dart
@@ -143,6 +143,7 @@ class _ConnectionManager {
   int _port;
   String _host;
   bool _ssl;
+  SecurityContext _context;
 
   BadCertHandlerType _badCertHandler = null;
 
@@ -159,7 +160,8 @@ class _ConnectionManager {
   /// The actual TCP/IP connection is not established.
   ///
 
-  _ConnectionManager(this._host, this._port, this._ssl, this._badCertHandler);
+  _ConnectionManager(this._host, this._port, this._ssl, this._badCertHandler,
+      [this._context]);
 
   //================================================================
   // Connecting
@@ -182,7 +184,7 @@ class _ConnectionManager {
       if (isClosed()) {
         var s = (_ssl)
             ? SecureSocket.connect(_host, _port,
-                onBadCertificate: _badCertHandler)
+                onBadCertificate: _badCertHandler, context: _context)
             : Socket.connect(_host, _port);
 
         _socket = await s;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,10 @@
 name: dartdap
-version: 0.2.1
+version: 0.2.2
 authors:
 - Warren Strange <warren.strange@gmail.com>
 - Chris Ridd <chrisridd@mac.com>
 - Hoylen Sue <hoylen@hoylen.com>
+- Matthew Butler <butler.matthew@gmail.com>
 description: LDAP v3 client library for Dart
 homepage: https://github.com/wstrange/dartdap
 environment:


### PR DESCRIPTION
This enabled client certificates or custom CA roots to be added when establishing
a secure connection.